### PR TITLE
When creating a top-level Space, check node_access() rather than og_user_access().

### DIFF
--- a/oa_subspaces.module
+++ b/oa_subspaces.module
@@ -51,7 +51,7 @@ function oa_subspaces_form_node_form_alter(&$form, $form_state, $form_id) {
     $parent_default['#description'] = t('Inherit membership from the selected parents.');
     $type = $form['#node']->type;
     $gid = oa_core_get_space_context();
-    $admin_access = og_user_access('node', $gid, "create $type content") || user_access('administer group');
+    $admin_access = user_access('administer group') || ($gid == 0 ? node_access('create', $type) : og_user_access('node', $gid, "create $type content"));
     if (empty($form['#node']->nid)) {
       // If they are being granted create permission based on group permission
       // restrict the parent field to current group so don't have to deal with


### PR DESCRIPTION
The change is pretty simple! It basically just checks node_access() (rather than og_user_access()) if we're at the top-level, since og_user_access() will always return FALSE.
